### PR TITLE
WIP: Add support for template plugins

### DIFF
--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -112,7 +112,7 @@ func (w WithShared) getConfigFile() string {
 	return string(w.Shared.ConfigFile)
 }
 
-type sharedOptions struct {
+type sharedOptionsCommon struct {
 	Spec                  flags.Filename `long:"spec" short:"f" description:"the spec file to use (default swagger.{json,yml,yaml})" group:"shared"`
 	Target                flags.Filename `long:"target" short:"t" default:"./" description:"the base directory for generating the files" group:"shared"`
 	Template              string         `long:"template" description:"load contributed templates" choice:"stratoscale" group:"shared"`
@@ -127,7 +127,7 @@ type sharedOptions struct {
 	FlattenCmdOptions
 }
 
-func (s sharedOptions) apply(opts *generator.GenOpts) {
+func (s sharedOptionsCommon) apply(opts *generator.GenOpts) {
 	opts.Spec = string(s.Spec)
 	opts.Target = string(s.Target)
 	opts.Template = s.Template

--- a/cmd/swagger/commands/generate/sharedopts_nonwin.go
+++ b/cmd/swagger/commands/generate/sharedopts_nonwin.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package generate
+
+import (
+	"github.com/go-swagger/go-swagger/generator"
+	"github.com/jessevdk/go-flags"
+)
+
+type sharedOptions struct {
+	sharedOptionsCommon
+	TemplatePlugin flags.Filename `long:"template-plugin" short:"p" description:"the template plugin to use" group:"shared"`
+}
+
+func (s sharedOptions) apply(opts *generator.GenOpts) {
+	opts.TemplatePlugin = string(s.TemplatePlugin)
+	s.sharedOptionsCommon.apply(opts)
+}

--- a/cmd/swagger/commands/generate/sharedopts_win.go
+++ b/cmd/swagger/commands/generate/sharedopts_win.go
@@ -1,0 +1,6 @@
+//go:build windows
+// +build windows
+
+package generate
+
+type sharedOptions sharedOptionsCommon

--- a/generator/genopts_nonwin.go
+++ b/generator/genopts_nonwin.go
@@ -1,0 +1,50 @@
+//go:build !windows
+// +build !windows
+
+package generator
+
+import (
+	"log"
+	"plugin"
+	"text/template"
+)
+
+type GenOpts struct {
+	GenOptsCommon
+	TemplatePlugin string
+}
+
+func (g *GenOpts) setTemplates() error {
+	if g.TemplatePlugin != "" {
+		if err := g.templates.LoadPlugin(g.TemplatePlugin); err != nil {
+			return err
+		}
+	}
+
+	return g.GenOptsCommon.setTemplates()
+}
+
+// LoadPlugin will load the named plugin and inject its functions into the funcMap
+//
+// The plugin must implement a function matching the signature:
+// `func AddFuncs(f template.FuncMap)`
+// which can add any number of functions to the template repository funcMap.
+// Any existing sprig or go-swagger templates with the same name will be overridden.
+func (t *Repository) LoadPlugin(pluginPath string) error {
+	log.Printf("Attempting to load template plugin: %s", pluginPath)
+
+	p, err := plugin.Open(pluginPath)
+
+	if err != nil {
+		return err
+	}
+
+	f, err := p.Lookup("AddFuncs")
+
+	if err != nil {
+		return err
+	}
+
+	f.(func(template.FuncMap))(t.funcs)
+	return nil
+}

--- a/generator/genopts_win.go
+++ b/generator/genopts_win.go
@@ -1,0 +1,6 @@
+//go:build windows
+// +build windows
+
+package generator
+
+type GenOpts GenOptsCommon

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -287,8 +287,8 @@ type SectionOpts struct {
 	Models          []TemplateOpts `mapstructure:"models"`
 }
 
-// GenOpts the options for the generator
-type GenOpts struct {
+// GenOptsCommon the options for the generator
+type GenOptsCommon struct {
 	IncludeModel               bool
 	IncludeValidator           bool
 	IncludeHandler             bool
@@ -763,7 +763,7 @@ func (g *GenOpts) renderDefinition(gg *GenDefinition) error {
 	return nil
 }
 
-func (g *GenOpts) setTemplates() error {
+func (g *GenOptsCommon) setTemplates() error {
 	if g.Template != "" {
 		// set contrib templates
 		if err := g.templates.LoadContrib(g.Template); err != nil {


### PR DESCRIPTION
This allows the use of go plugins to supply your own custom template
functions for generating code from custom templates with go-swagger.

Builds plugin functionality in only for non-windows builds.

Signed-off-by: Kevin Barbour <kevinbarbourd@gmail.com>